### PR TITLE
PLATFORM-3070 do not expect a platform when getting an item by nftAddress

### DIFF
--- a/src/functions/update-item.ts
+++ b/src/functions/update-item.ts
@@ -66,11 +66,7 @@ export async function updateItemHandler(req: Request, res: Response, config: All
   let auditEntity: AuditEntity = null;
 
   try {
-    if (pathParams.keyType === 'nftAddress') {
-      itemEntity = await repository().byNftAddress(pathParams.platform, pathParams.key, context);
-    } else {
-      itemEntity = await repository().byThumbprint(pathParams.platform, pathParams.key, context);
-    }
+    itemEntity = await repository().byThumbprint(pathParams.platform, pathParams.key, context);
 
     if (!itemEntity) {
       throw new AppError(ITEM_NOT_FOUND(pathParams.platform, pathParams.key));

--- a/src/helpers/util.ts
+++ b/src/helpers/util.ts
@@ -33,7 +33,6 @@ export async function getSkuOrThrow(cfg: AllConfig, skuCode: string): Promise<Sk
 }
 
 export type ItemPathParams = {
-  keyType: 'token' | 'nftAddress';
   key: string;
   platform: string;
   retailer: boolean;
@@ -49,12 +48,7 @@ export function parsePath(req: Request, res: Response): ItemPathParams | null {
   }
 
   const platform = parts[parts.length - 2];
+  const key = parts[parts.length - 1];
 
-  let key = parts[parts.length - 1];
-  const keyType = key.startsWith('nft.') ? 'nftAddress' : 'token';
-  if (keyType === 'nftAddress') {
-    key = key.substring(4);
-  }
-
-  return { keyType, key, platform, retailer };
+  return { key, platform, retailer };
 }

--- a/src/persistence/item-repository.ts
+++ b/src/persistence/item-repository.ts
@@ -65,8 +65,8 @@ export class ItemRepository {
     }
   }
 
-  public async byNftAddress(platformCode: string, nftAddress: string, context?: DatastoreContext): Promise<ItemEntity | null> {
-    logger.debug(`byNftAddress - platformCode = '${platformCode}' nftAddress = '${nftAddress}'`)
+  public async byNftAddress(nftAddress: string, context?: DatastoreContext): Promise<ItemEntity | null> {
+    logger.debug(`byNftAddress - nftAddress = '${nftAddress}'`)
 
     const items: ItemEntity[] = await findEntities(
       context ?? ItemRepository.context,
@@ -75,7 +75,7 @@ export class ItemRepository {
     );
 
     const item = items.length > 0 ? items[0] : null;
-    if (item && item.platformCode === platformCode && item.state !== 'DELETED') {
+    if (item && item.state !== 'DELETED') {
       return item;
     } else {
       return null;

--- a/test/functions/get-item.test.ts
+++ b/test/functions/get-item.test.ts
@@ -191,14 +191,14 @@ describe('function - get-item - internal', () => {
 
   it('returns item by nftAddress', async () => {
     const nftAddress = 'SOL.devnet.abc123';
-    req.path = `/${platform}/nft.${nftAddress}`;
+    req.path = `/_NFT_/${nftAddress}`;
 
     await instance(req, res);
 
     expect(res.statusCode).toEqual(StatusCodes.OK);
     expect(byThumbprintSpy).toHaveBeenCalledTimes(0);
     expect(byNftAddressSpy).toHaveBeenCalledTimes(1);
-    expect(byNftAddressSpy).toHaveBeenLastCalledWith(platform, nftAddress);
+    expect(byNftAddressSpy).toHaveBeenLastCalledWith(nftAddress);
     expect(res._getJSON()).toEqual({
       ...SALE_DTO_INTERNAL,
       nftAddress: 'SOL.devnet.12345',

--- a/test/persistence/item-repository.test.ts
+++ b/test/persistence/item-repository.test.ts
@@ -298,7 +298,7 @@ describe('persistence', () => {
     });
 
     it('uses correct query', async () => {
-      await instance.byNftAddress(PLATFORM, SALE_ENTITY_MINTED.nftAddress as string);
+      await instance.byNftAddress(SALE_ENTITY_MINTED.nftAddress as string);
 
       const expectedQuery = {
         namespace: 'drm',
@@ -311,22 +311,16 @@ describe('persistence', () => {
     });
 
     it('transforms results', async () => {
-      const result = await instance.byNftAddress(PLATFORM, SALE_ENTITY_MINTED.nftAddress as string);
+      const result = await instance.byNftAddress(SALE_ENTITY_MINTED.nftAddress as string);
 
       expect(result).toEqual(SALE_ENTITY_MINTED);
-    });
-
-    it('returns null for platform mismatch', async () => {
-      const result = await instance.byNftAddress('INVALID', SALE_ENTITY_MINTED.nftAddress as string);
-
-      expect(result).toEqual(null);
     });
 
     it('returns null for DELETED state', async () => {
       runQuerySpy.mockReset();
       runQuerySpy.mockReturnValueOnce([[{ ...SALE_QUERY_DATA_MINTED, state: 'DELETED' }]] as any);
 
-      const result = await instance.byNftAddress(PLATFORM, SALE_ENTITY_MINTED.nftAddress as string);
+      const result = await instance.byNftAddress(SALE_ENTITY_MINTED.nftAddress as string);
 
       expect(result).toEqual(null);
     });


### PR DESCRIPTION
I've realised that we cannot expect a platform when querying by nftAddress.  When listening for NFT transfers all nft-service will know is the nftAddress.

I've therefore slightly changed the approach:
- Use a special platform of `_NFT_` if we want to get by nftAddress (only supported for non-retailers)
- Only support nftAddress for get and not update.  It's only ever needed by nft-service to convert an nftAddress into an item token (while also confirming the item actually exists and is minted)